### PR TITLE
Guard against null reference when gem base is missing

### DIFF
--- a/canjewelry/canjewelry/src/items/ProcessedGem.cs
+++ b/canjewelry/canjewelry/src/items/ProcessedGem.cs
@@ -169,7 +169,7 @@ namespace canjewelry.src.jewelry
                 
                 gemBase = itree.GetString("gembase");
 
-                if (gemBase.Equals("olivine_peridot"))
+                if ("olivine_peridot".Equals(gemBase))
                 {
                     gemBase = "olivine";
                 }
@@ -197,7 +197,7 @@ namespace canjewelry.src.jewelry
             }
             else
             {
-                if (gemBase.Equals("olivine_peridot"))
+                if ("olivine_peridot".Equals(gemBase))
                 {
                     gemBase = "olivine";
                 }
@@ -234,7 +234,7 @@ namespace canjewelry.src.jewelry
 
                 gemBase = itree.GetString("gembase");
 
-                if (gemBase.Equals("olivine_peridot"))
+                if ("olivine_peridot".Equals(gemBase))
                 {
                     gemBase = "olivine";
                 }
@@ -262,7 +262,7 @@ namespace canjewelry.src.jewelry
             }
             else
             {
-                if (gemBase.Equals("olivine_peridot"))
+                if ("olivine_peridot".Equals(gemBase))
                 {
                     gemBase = "olivine";
                 }


### PR DESCRIPTION
Prevent NullReferenceException when gemBase is null by calling Equals on the literal instead.

```
05-Jun-26 00:07:12: Critical error occurred in the following mod: canjewelry@0.6.12
Loaded Mods: betterandimprovedweather@0.1.8, chandeliercraft@2.1.1, chiseltools@1.17.2, cindersandembers@1.0.2, elshadowsp@1.0.2, foodcrate@2.2.1, fuelbriquettes@1.0.2, geoaddons@1.4.7, glasstrapdoor@1.0.2, horperfopt@1.0.5, hydrateordiedrate@2.4.12, jsonpatcheslib@1.5.3, logtosticks@1.0.0, millwright@1.3.3, morebanners@1.3.2, morepolishedrocks@1.0.2, overhaulliblegacycompat@1.1.12, overhaullib@2.0.8, prospecttogether@2.2.1, quarterlogconverter@1.0.0, racialequality@0.1.28, scrolled@1.1.9, sortablestorage@3.0.0, stonequarryrepckfipil@3.6.3, storagecontroller@1.2.2, temporalsymphony@2.3.2, temporalweaponsfork@1.1.2, temporal_gears_stack@1.0.0, terratag@0.4.5, toneddownpredatorsfork@1.1.0, game@1.22.3, vsimgui@1.2.5, aculinaryartillery@2.0.0-dev.19, animalcages@5.0.0, animationslib@0.0.2, attributerenderinglibrary@3.1.4, egocaribautomapmarkers@5.0.3, bedspawnv2@1.7.0, betterruins@0.6.2, billposting@2.0.0, bitterbrew@1.9.0, blacksmithname@1.3.0, boattags@1.2.2, manifest@1.3.0, canjewelry@0.6.12, carryonlib@1.0.0-pre.2, championandelitemobs@0.2.1, clothierheirloomsmod@1.1.0, coloredcabinets@1.1.0, commonlibforked@2.8.1, configlib@1.12.0, thecritterpackcontinued@1.4.1, deathcorpses@2.8.1, decoclockrevival@1.22.2, effectshud@0.3.3, elkphysics@3.0.3, elkvariants@3.6.2, extendedcreation@1.2.5, farseer@1.4.0, firearmsfork@1.9.14, foodpreferences@1.5.5, foodshelves@3.0.4, fromgoldencombs@2.0.7, herbarium@1.4.2-rc.1, hudclockpatch@4.3.1, ithaniacannedgoods@2.0.5, japanesearchitecture@0.9.7, longburningfirewood@1.0.2, mngeology@2.0.7, materialneeds@1.1.16, medievalexpansionpatch@1.4.1, meteoricsteel@1.0.15, mobsradar@3.0.0, nbcartographer@2.3.0, needpolishedrocks@1.1.1, noticeboard@2.0.2, optitime@1.5.12, panningmachine@1.0.11, pelaguswinds@1.2.2, placeonslabs@1.1.3, playermodellib@1.19.3, purposefulstorage@2.0.1, rustboundmagic@3.2.2, saltandsands@1.3.0, scaffolding@1.3.1, seamlessrapids@1.0.1, shadehouse@1.2.1, slowtox@5.0.0, soundofconfession@1.1.1, spyglass@0.6.1, stonebakeoven@1.3.4, substrate@2.0.0, tpnetpatched@1.15.1, terratagsoundspack@0.1.1, improvedmetallurgy@1.1.5, traitacquirermoddedclasses@0.9.13, vanity@2.5.1-rc.1, vsairshipmod@1.1.4, creative@1.22.3, vsroofing@1.5.7, survival@1.22.3, watersheds@6.3.6, wildgrasscontinued@1.3.11, windchimes@1.5.2, woodenfortifications@2.0.11, carryon@2.0.0-pre.2, combatoverhaulfork@0.17.49, crossbowsfork@1.9.13, expandedfoods@2.0.0-dev.8, em@3.6.1, heraldry@2.0.0, justchairs@0.1.0, koboldrdx@1.4.8, mnflowers@0.0.0, simplealchemy@2.3.4, terrainslabs@1.0.16, wildcraftfruit@1.4.61, wildcrafttree@1.3.4, xinvtweaks@1.8.1, aldiclasses@2.1.1, armoryfork@1.10.31, combatreanimatedfork@1.0.1, heraldrybanners@2.0.0, justchairsyksbedits@1.0.0, aldiclassesadvancedfeatures@2.1.1, traitacquirermoddedaldibooks@1.1.1
Involved Harmony IDs: firearmsfork.render-variant-sanitizer, spyglass, com.zaldaryon.optitime
System.NullReferenceException: Object reference not set to an instance of an object.
   at canjewelry.src.jewelry.ProcessedGem.GenMesh(ItemStack itemstack, ITextureAtlasAPI targetAtlas, BlockPos atBlockPos) in C:\Users\koeni\source\repos\CAN_Jewelry\canjewelry\canjewelry\src\items\ProcessedGem.cs:line 265
   at canjewelry.src.jewelry.ProcessedGem.OnBeforeRender(ICoreClientAPI capi, ItemStack itemstack, EnumItemRenderTarget target, ItemRenderInfo& renderinfo) in C:\Users\koeni\source\repos\CAN_Jewelry\canjewelry\canjewelry\src\items\ProcessedGem.cs:line 141
   at Vintagestory.Client.NoObf.InventoryItemRenderer.GetItemStackRenderInfo_Patch1(ClientMain game, ItemSlot inSlot, EnumItemRenderTarget target, Single dt)
   at Vintagestory.Client.NoObf.RenderAPIGame.GetItemStackRenderInfo(ItemSlot inSlot, EnumItemRenderTarget target, Single dt) in VintagestoryLib\Client\API\RenderAPIGame.cs:line 197
   at Vintagestory.GameContent.EntityItemRenderer.DoRender3DOpaque(Single dt, Boolean isShadowPass) in VSEssentials\EntityRenderer\EntityItemRenderer.cs:line 136
   at Vintagestory.Client.NoObf.SystemRenderEntities.OnRenderOpaque3D_Patch1(SystemRenderEntities this, Single deltaTime)
   at Vintagestory.API.Client.DummyRenderer.OnRenderFrame(Single deltaTime, EnumRenderStage stage) in VintagestoryApi\Client\API\IClientEventAPI.cs:line 88
   at Vintagestory.Client.NoObf.ClientEventManager.TriggerRenderStage(EnumRenderStage stage, Single dt) in VintagestoryLib\Client\Util\ClientEventManager.cs:line 257
   at Vintagestory.Client.NoObf.ClientMain.TriggerRenderStage(EnumRenderStage stage, Single dt) in VintagestoryLib\Client\ClientMain.cs:line 858
   at Vintagestory.Client.NoObf.ClientMain.MainRenderLoop(Single dt) in VintagestoryLib\Client\ClientMain.cs:line 953
   at Vintagestory.Client.NoObf.ClientMain.MainGameLoop(Single deltaTime) in VintagestoryLib\Client\ClientMain.cs:line 782
   at Vintagestory.Client.GuiScreenRunningGame.RenderToPrimary(Single dt) in VintagestoryLib\Client\MainMenu\Screens\GuiScreenRunningGame.cs:line 173
   at Vintagestory.Client.ScreenManager.Render(Single dt) in VintagestoryLib\Client\ScreenManager.cs:line 742
   at Vintagestory.Client.ScreenManager.OnNewFrame_Patch1(ScreenManager this, Single dt)
   at Vintagestory.Client.NoObf.ClientPlatformWindows.window_RenderFrame_Patch1(ClientPlatformWindows this, FrameEventArgs e)
   at OpenTK.Windowing.Desktop.GameWindow.Run()
   at Vintagestory.Client.ClientProgram.Start(ClientProgramArgs args, String[] rawArgs) in VintagestoryLib\Client\ClientProgram.cs:line 354
   at Vintagestory.Client.ClientProgram.<>c__DisplayClass10_0.<.ctor>b__1() in VintagestoryLib\Client\ClientProgram.cs:line 131
   at Vintagestory.ClientNative.CrashReporter.Start(ThreadStart start) in VintagestoryLib\Client\ClientPlatform\ClientNative\CrashReporter.cs:line 95
```

As for how the invalid gem came to exist, I'm not sure. It dropped from a locust and crashed anyone who got near it, but I have no idea if it was a bad mod interaction (as you can see from the log, our server is running a kind of excessive amount) or this mod.

I'll be honest, I did this in the web editor because I don't have a C# environment set up. I assume it should work properly, but I did not compile and test it myself.